### PR TITLE
Enclose application name in single quoutes

### DIFF
--- a/src/rebar_raw_resource.erl
+++ b/src/rebar_raw_resource.erl
@@ -611,7 +611,7 @@ ensure_app(Path, Mod, Name, Opts, Result) ->
                 "%%\n"
                 % this is the minimum set of elements required to make rebar
                 % happy when there are no sources for it to compile
-                "{application,   ~s,\n"
+                "{application,   \'~s\',\n"
                 "[\n"
                 "    {description,   \"~s\"},\n"
                 "    {vsn,           \"~s\"},\n"


### PR DESCRIPTION
To handle non alphanumerical application names such as
'some-dependency' they need to be encapsulated in single quoutes.