### PR TITLE
Compile on OTP 27

### DIFF
--- a/src/rebar_raw_resource.erl
+++ b/src/rebar_raw_resource.erl
@@ -51,7 +51,6 @@
 % For development only - you *really* don't want this defined!
 %-define(RRR_DEBUG,  true).
 
--define(else,   'true').
 -define(is_min_tuple(Var, Min),
     erlang:is_tuple(Var) andalso erlang:tuple_size(Var) >= Min).
 -define(is_rec_type(Var, Type, Min),


### PR DESCRIPTION
Hi,

This PR proposes a fix for the following error when building `rebar_raw_resource` on OTP 27.0-rc1:
```
_build/test/plugins/rebar_raw_resource/src/rebar_raw_resource.erl:54:9: badly formed 'define' 
```

It looks like 'else' became a reserved word. In any case, the macro in question is not being used.